### PR TITLE
Fix : checkbox must be inside the label tag

### DIFF
--- a/views/index.blade.php
+++ b/views/index.blade.php
@@ -36,8 +36,10 @@
                                                 </div>
                                             @else
                                                 <p>
-                                                    <input type="checkbox" id="id{{ ++$idIndex }}" name="option_{{ $option->getName() }}">
-                                                    <label for="id{{ $idIndex }}">{{ $option->getDescription() }}</label>
+                                                    <label for="id{{ ++$idIndex }}">
+                                                        <input type="checkbox" id="id{{ $idIndex }}" name="option_{{ $option->getName() }}">
+                                                        <span>{{ $option->getDescription() }}</span>
+                                                    </label>
                                                 </p>
                                             @endif
                                         @endforeach


### PR DESCRIPTION
For the check boxes provided by materialize display correctly, we must put the checkbox inside the label tag.